### PR TITLE
Bump to version 0.2.0-SNAPSHOT to reflect packaging changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.lambdamatic</groupId>
 	<artifactId>lambdamatic-analyzer</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>Lambda Expression Bytecode Reader</name>
 
 	<description>A library to read the synthetic (ie, generated) bytecode of Lambda Expressions


### PR DESCRIPTION
Unneccessary dependencies were removed and ASM has been shaded
Bump should have happened earlier, but it slipped...