### PR TITLE
[fix] Fixing statements order in result

### DIFF
--- a/src/main/java/org/lambdamatic/analyzer/LambdaExpressionAnalyzer.java
+++ b/src/main/java/org/lambdamatic/analyzer/LambdaExpressionAnalyzer.java
@@ -227,7 +227,7 @@ public class LambdaExpressionAnalyzer {
         lambdaInfo.getImplMethodName());
     final LambdaExpressionReader lambdaExpressionReader = new LambdaExpressionReader();
     final Pair<List<Statement>, List<LocalVariable>> bytecode =
-        lambdaExpressionReader.readBytecodeStatement(lambdaInfo);
+        lambdaExpressionReader.readBytecodeStatements(lambdaInfo);
     final List<LocalVariable> lambdaExpressionArguments = bytecode.getRight();
     final List<Statement> lambdaExpressionStatements = bytecode.getLeft();
     final List<Statement> processedBlock = lambdaExpressionStatements.stream().map(LambdaExpressionAnalyzer::thinOut)

--- a/src/main/java/org/lambdamatic/analyzer/ast/InsnCursor.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/InsnCursor.java
@@ -44,7 +44,7 @@ class InsnCursor {
   private final Map<String, AbstractInsnNode> labels;
 
   /**
-   * Constructor
+   * Constructor.
    * 
    * @param instructions the {@link InsnList} to iterate on.
    * @param labels the labels to locate specific instructions.
@@ -201,6 +201,15 @@ class InsnCursor {
       duplicateCursor.next();
     }
     return duplicateCursor;
+  }
+  
+  /**
+   * Indicates if the given {@code instruction} has a label in the bytecode.
+   * @param instruction the instruction to check
+   * @return <code>true</code> if the instruction is labelled, <code>false</code> otherwise
+   */
+  public boolean isLabelled(final AbstractInsnNode instruction) {
+    return this.labels.containsValue(instruction);
   }
 
 }

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/NodeUtils.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/NodeUtils.java
@@ -29,16 +29,16 @@ public class NodeUtils {
   /**
    * Returns the given statement as a pretty formatted {@link String}
    * 
-   * @param statement the statement
+   * @param node the statement
    * @return the pretty formatted representation of the given statement.
    */
-  public static String prettyPrint(final Node statement) {
+  public static String prettyPrint(final Node node) {
     try {
       final StringBuilder builder = new StringBuilder();
       int indent = 0;
       // reads the statement and insert CR/LF and indentations when
       // crossing curly brackets.
-      StringReader reader = new StringReader(statement.toString());
+      StringReader reader = new StringReader(node.toString());
       char current;
       while ((current = (char) reader.read()) != EOS) {
         if (current == '{') {
@@ -60,7 +60,7 @@ public class NodeUtils {
       }
       return builder.toString();
     } catch (IOException e) {
-      LOGGER.warn("Failed to pretty print the given statement: " + statement, e);
+      LOGGER.warn("Failed to pretty print the given statement: " + node, e);
       return null;
     }
   }

--- a/src/test/java/org/lambdamatic/analyzer/SerializableConsumerExpressionBytecodeAnalyzerTest.java
+++ b/src/test/java/org/lambdamatic/analyzer/SerializableConsumerExpressionBytecodeAnalyzerTest.java
@@ -12,7 +12,9 @@ package org.lambdamatic.analyzer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.lambdamatic.testutils.JavaMethods.ArrayUtil_toArray;
+import static org.lambdamatic.testutils.JavaMethods.Date_getTime;
 import static org.lambdamatic.testutils.JavaMethods.Object_equals;
+import static org.lambdamatic.testutils.JavaMethods.Object_notify;
 import static org.lambdamatic.testutils.JavaMethods.TestPojo_elementMatch;
 
 import java.io.IOException;
@@ -112,6 +114,11 @@ public class SerializableConsumerExpressionBytecodeAnalyzerTest {
             new MethodInvocation(e_dot_field, Object_equals, new StringLiteral("foo"))),
         TestPojo.class, "e");
     final EmbeddedTestPojo embeddedTestPojo = new EmbeddedTestPojo();
+    final MethodInvocation e_dot_field_dot_notify =
+        new MethodInvocation(e_dot_field, Object_notify);
+    final FieldAccess e_dot_dateValue = new FieldAccess(testPojo, "dateValue");
+    final MethodInvocation e_dot_dateValue_dot_getTime =
+        new MethodInvocation(e_dot_dateValue, Date_getTime);
 
     return new Object[][] {
         match(t -> ArrayUtil.toArray(t.stringValue, t.dateValue),
@@ -194,7 +201,11 @@ public class SerializableConsumerExpressionBytecodeAnalyzerTest {
                 new Operation(Operator.ADD, testPojo_dot_primitiveIntValue, new NumberLiteral(1))),
             new MethodInvocation(testPojo_dot_elementList, JavaMethods.List_add,
                 new CapturedArgument(embeddedTestPojo)))),
-
+        match(t -> {
+          t.field.notify();
+          t.dateValue.getTime();
+        }, Arrays.array(e_dot_field_dot_notify, e_dot_dateValue_dot_getTime))
+           
     };
   }
 

--- a/src/test/java/org/lambdamatic/testutils/JavaMethods.java
+++ b/src/test/java/org/lambdamatic/testutils/JavaMethods.java
@@ -11,6 +11,7 @@
 package org.lambdamatic.testutils;
 
 import java.lang.reflect.Method;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -29,12 +30,8 @@ import com.sample.model.TestPojo;
  */
 public class JavaMethods {
 
-  public static Method Object_equals;
-
   public static Method TestPojo_elementMatch;
-
-  public static Method ArrayUtil_toArray;
-
+  
   public static Method TestPojo_getStringValue;
 
   public static Method TestPojo_getPrimitiveBooleanValue;
@@ -85,9 +82,19 @@ public class JavaMethods {
   
   public static Method Character_valueOf;
   
+  public static Method Object_equals;
+  
+  public static Method Object_notify;
+  
+  public static Method Date_getTime;
+  
+  public static Method ArrayUtil_toArray;
+  
   static {
     try {
       Object_equals = Object.class.getMethod("equals", Object.class);
+      Object_notify = Object.class.getMethod("notify");
+      Date_getTime = Date.class.getMethod("getTime");
       TestPojo_elementMatch = TestPojo.class.getMethod("elementMatch", SerializablePredicate.class);
       ArrayUtil_toArray = ArrayUtil.class.getMethod("toArray", Object[].class);
       TestPojo_getStringValue = TestPojo.class.getMethod("getStringValue");
@@ -115,7 +122,7 @@ public class JavaMethods {
       List_get = List.class.getMethod("get", int.class);
       Map_get = Map.class.getMethod("get", Object.class);
       Character_valueOf = Character.class.getMethod("valueOf", char.class);
-
+      
     } catch (NoSuchMethodException | SecurityException e) {
       e.printStackTrace();
       Assert.fail("Failed to retrieve Java method");


### PR DESCRIPTION
If one of the statements returned 'void', the order of the
statements in the analysis result would be wrong.