### PR TITLE
Relocating the ASM classes while shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
 									<include>org.ow2.asm:asm-all</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.objectweb.asm</pattern>
+									<shadedPattern>org.lambdamatic.shaded.objectweb.asm</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Relocating all ASM classes under 'org.lambdamatic.shaded.objectweb.asm'
while shading, to make sure there will be no conflict with any consumer
application or library that would rely on another version of ASM for
any other purpose.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>