### PR TITLE
Renaming ...Type() methods

### DIFF
--- a/src/main/java/org/lambdamatic/analyzer/LambdaExpressionAnalyzer.java
+++ b/src/main/java/org/lambdamatic/analyzer/LambdaExpressionAnalyzer.java
@@ -242,7 +242,7 @@ public class LambdaExpressionAnalyzer {
   }
 
   private static Statement simplify(final Statement statement) {
-    switch (statement.getStatementType()) {
+    switch (statement.getType()) {
       case CONTROL_FLOW_STMT:
         final ControlFlowStatement controlFlowStmt = (ControlFlowStatement) statement;
         final Expression simplifiedControlFlowExpression =
@@ -263,7 +263,7 @@ public class LambdaExpressionAnalyzer {
         return new ReturnStatement(simplifiedReturnExpression);
       default:
         throw new AnalyzeException(
-            "Unexpected statement type to simplify: " + statement.getStatementType());
+            "Unexpected statement type to simplify: " + statement.getType());
     }
   }
 
@@ -273,7 +273,7 @@ public class LambdaExpressionAnalyzer {
    *         otherwise returns the given {@link Expression}.
    */
   private static Expression simplify(final Expression expression) {
-    if (expression.getExpressionType() == ExpressionType.COMPOUND) {
+    if (expression.getType() == ExpressionType.COMPOUND) {
       final CompoundExpression infixExpression = (CompoundExpression) expression;
       final Expression simplifiedExpression = infixExpression.simplify();
       return ExpressionVisitorUtil.visit(simplifiedExpression, new ExpressionSanitizer());
@@ -313,7 +313,7 @@ public class LambdaExpressionAnalyzer {
    */
   private static Statement thinOut(final Statement statement) {
     LOGGER.debug("About to simplify \n\t{}", NodeUtils.prettyPrint(statement));
-    if (statement.getStatementType() == StatementType.EXPRESSION_STMT) {
+    if (statement.getType() == StatementType.EXPRESSION_STMT) {
       return statement;
     }
     // find branches that end with 'return 1'
@@ -329,7 +329,7 @@ public class LambdaExpressionAnalyzer {
       // the path that was taken (in case of ConditionalStatements)
       Statement previousStmt = null;
       while (currentStmt != null) {
-        switch (currentStmt.getStatementType()) {
+        switch (currentStmt.getType()) {
           case CONTROL_FLOW_STMT:
             final ControlFlowStatement controlFlowStatement = (ControlFlowStatement) currentStmt;
             final Expression controlFlowExpression =
@@ -344,7 +344,7 @@ public class LambdaExpressionAnalyzer {
             break;
           case RETURN_STMT:
             final Expression returnExpression = ((ReturnStatement) currentStmt).getExpression();
-            if (returnExpression.getExpressionType() == ExpressionType.METHOD_INVOCATION) {
+            if (returnExpression.getType() == ExpressionType.METHOD_INVOCATION) {
               relevantExpressions.add(0, returnExpression);
             }
             break;

--- a/src/main/java/org/lambdamatic/analyzer/ast/CapturedArgumentsEvaluator.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/CapturedArgumentsEvaluator.java
@@ -79,7 +79,7 @@ public class CapturedArgumentsEvaluator extends ExpressionVisitor {
 
   @Override
   public boolean visitFieldAccessExpression(final FieldAccess fieldAccess) {
-    if (fieldAccess.getSource().getExpressionType() == ExpressionType.OBJECT_INSTANCE) {
+    if (fieldAccess.getSource().getType() == ExpressionType.OBJECT_INSTANCE) {
       final String fieldName = fieldAccess.getFieldName();
       try {
         final Object source = fieldAccess.getSource().getValue();
@@ -90,8 +90,8 @@ public class CapturedArgumentsEvaluator extends ExpressionVisitor {
         if (parentExpression != null) {
           final Expression fieldAccessReplacement = ExpressionFactory.getExpression(replacement);
           LOGGER.trace(" replacing {} ({}) with {} ({})", fieldAccess,
-              fieldAccess.getExpressionType(), fieldAccessReplacement,
-              fieldAccessReplacement.getExpressionType());
+              fieldAccess.getType(), fieldAccessReplacement,
+              fieldAccessReplacement.getType());
           parentExpression.replaceElement(fieldAccess, fieldAccessReplacement);
         }
         // no further visiting on this (obsolete) branch of the expression tree.

--- a/src/main/java/org/lambdamatic/analyzer/ast/ExpressionSanitizer.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/ExpressionSanitizer.java
@@ -59,10 +59,10 @@ public class ExpressionSanitizer extends ExpressionVisitor {
     if ((expr.getOperator() == CompoundExpressionOperator.EQUALS
         || expr.getOperator() == CompoundExpressionOperator.NOT_EQUALS)
         && expr.getOperands().size() == 2 && expr.getOperands().stream()
-            .anyMatch(e -> e.getExpressionType() == ExpressionType.BOOLEAN_LITERAL)) {
+            .anyMatch(e -> e.getType() == ExpressionType.BOOLEAN_LITERAL)) {
       final ComplexExpression parentExpression = expr.getParent();
       final Optional<Expression> replacementExpr = expr.getOperands().stream()
-          .filter(e -> e.getExpressionType() != ExpressionType.BOOLEAN_LITERAL).findFirst();
+          .filter(e -> e.getType() != ExpressionType.BOOLEAN_LITERAL).findFirst();
       if (replacementExpr.isPresent()) {
         parentExpression.replaceElement(expr,
             (expr.getOperator() == CompoundExpressionOperator.EQUALS) ? replacementExpr.get()
@@ -114,7 +114,7 @@ public class ExpressionSanitizer extends ExpressionVisitor {
    */
   @Override
   public boolean visitFieldAccessExpression(final FieldAccess fieldAccess) {
-    if (fieldAccess.getSource().getExpressionType() == ExpressionType.CLASS_LITERAL) {
+    if (fieldAccess.getSource().getType() == ExpressionType.CLASS_LITERAL) {
       final ClassLiteral sourceClass = (ClassLiteral) fieldAccess.getSource();
       final String fieldName = fieldAccess.getFieldName();
       try {
@@ -126,8 +126,8 @@ public class ExpressionSanitizer extends ExpressionVisitor {
         if (parentExpression != null) {
           final Expression fieldAccessReplacement = ExpressionFactory.getExpression(replacement);
           LOGGER.trace(" replacing {} ({}) with {} ({})", fieldAccess,
-              fieldAccess.getExpressionType(), fieldAccessReplacement,
-              fieldAccessReplacement.getExpressionType());
+              fieldAccess.getType(), fieldAccessReplacement,
+              fieldAccessReplacement.getType());
           parentExpression.replaceElement(fieldAccess, fieldAccessReplacement);
         }
         // no further visiting on this (obsolete) branch of the expression tree.

--- a/src/main/java/org/lambdamatic/analyzer/ast/LambdaExpressionReader.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/LambdaExpressionReader.java
@@ -432,9 +432,9 @@ public class LambdaExpressionReader {
     final List<CapturedArgumentRef> lambdaArgs = new ArrayList<>();
     for (int i = 0; i < argNumber; i++) {
       final Expression expr = operandStack.pollLast();
-      if (expr.getExpressionType() != ExpressionType.CAPTURED_ARGUMENT_REF) {
+      if (expr.getType() != ExpressionType.CAPTURED_ARGUMENT_REF) {
         throw new AnalyzeException("Unexpected argument type when following InvokeDynamic call: "
-            + expr.getExpressionType());
+            + expr.getType());
       }
       lambdaArgs.add((CapturedArgumentRef) expr); // , expr.getValue()
     }
@@ -824,7 +824,7 @@ public class LambdaExpressionReader {
       return new NumberLiteral(-value.intValue());
     } catch (ClassCastException e) {
       throw new AnalyzeException(
-          "Cannot perform the inversion of operand of type " + operand.getExpressionType(), e);
+          "Cannot perform the inversion of operand of type " + operand.getType(), e);
     }
   }
 
@@ -1008,7 +1008,7 @@ public class LambdaExpressionReader {
    * @return the casted operand or the given operand if no cast could be performed
    */
   private static Expression castOperand(final Expression operand, final String targetTypeName) {
-    if (operand.getExpressionType() == ExpressionType.NUMBER_LITERAL) {
+    if (operand.getType() == ExpressionType.NUMBER_LITERAL) {
       return ExpressionFactory.getLiteral((NumberLiteral) operand, targetTypeName);
     }
     return operand;
@@ -1021,7 +1021,7 @@ public class LambdaExpressionReader {
    * @see MethodInvocation#getReturnType()
    */
   private static Class<?> getOperandType(final Expression operand) {
-    if (operand.getExpressionType() == ExpressionType.METHOD_INVOCATION) {
+    if (operand.getType() == ExpressionType.METHOD_INVOCATION) {
       return ((MethodInvocation) operand).getReturnType();
     }
     return operand.getJavaType();
@@ -1036,7 +1036,7 @@ public class LambdaExpressionReader {
    * @throws AnalyzeException when no default {@link Expression} can be provided.
    */
   private static Expression getDefaultComparisonOperand(final Expression expression) {
-    if (expression != null && expression.getExpressionType() == ExpressionType.METHOD_INVOCATION) {
+    if (expression != null && expression.getType() == ExpressionType.METHOD_INVOCATION) {
       final MethodInvocation methodInvocation = (MethodInvocation) expression;
       // if the expression is something like 'a.equals(b)', there's no need to add an extra ' ==
       // true' in the
@@ -1061,7 +1061,7 @@ public class LambdaExpressionReader {
       } else if (methodReturnType.equals(String.class)) {
         return new NullLiteral();
       }
-    } else if (expression != null && expression.getExpressionType() == ExpressionType.FIELD_ACCESS
+    } else if (expression != null && expression.getType() == ExpressionType.FIELD_ACCESS
         && (expression.getJavaType() == Boolean.class
             || expression.getJavaType() == boolean.class)) {
       return new BooleanLiteral(false);

--- a/src/main/java/org/lambdamatic/analyzer/ast/ReturnTruePathFilter.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/ReturnTruePathFilter.java
@@ -36,7 +36,7 @@ public class ReturnTruePathFilter extends StatementVisitor {
   @Override
   public boolean visitReturnStatement(final ReturnStatement returnStatement) {
     final Expression returnExpression = returnStatement.getExpression();
-    switch (returnExpression.getExpressionType()) {
+    switch (returnExpression.getType()) {
       case BOOLEAN_LITERAL:
         final BooleanLiteral booleanLiteral = (BooleanLiteral) returnExpression;
         if (booleanLiteral.getValue().equals(true)) {
@@ -59,7 +59,7 @@ public class ReturnTruePathFilter extends StatementVisitor {
         break;
       default:
         throw new AnalyzeException(
-            "Unsupported expression type (" + returnExpression.getExpressionType().toString()
+            "Unsupported expression type (" + returnExpression.getType().toString()
                 + ") in return statement '" + returnStatement.toString() + "'");
     }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ArrayElementAccess.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ArrayElementAccess.java
@@ -75,7 +75,7 @@ public class ArrayElementAccess extends Expression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.ARRAY_ELEMENT_ACCESS;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ArrayVariable.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ArrayVariable.java
@@ -87,10 +87,10 @@ public class ArrayVariable extends ComplexExpression {
   }
 
   /**
-   * @see org.lambdamatic.analyzer.ast.node.Expression#getExpressionType()
+   * @see org.lambdamatic.analyzer.ast.node.Expression#getType()
    */
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.ARRAY_VARIABLE;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/Assignment.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/Assignment.java
@@ -52,7 +52,7 @@ public class Assignment extends ComplexExpression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.ASSIGNMENT;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/BooleanLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/BooleanLiteral.java
@@ -59,10 +59,10 @@ public class BooleanLiteral extends ObjectInstance {
   /**
    * {@inheritDoc}
    * 
-   * @see org.lambdamatic.analyzer.ast.node.Expression#getExpressionType()
+   * @see org.lambdamatic.analyzer.ast.node.Expression#getType()
    */
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.BOOLEAN_LITERAL;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/CapturedArgument.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/CapturedArgument.java
@@ -56,7 +56,7 @@ public class CapturedArgument extends Expression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.CAPTURED_ARGUMENT;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/CapturedArgumentRef.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/CapturedArgumentRef.java
@@ -83,7 +83,7 @@ public class CapturedArgumentRef extends Expression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.CAPTURED_ARGUMENT_REF;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/CharacterLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/CharacterLiteral.java
@@ -45,7 +45,7 @@ public class CharacterLiteral extends ObjectInstance {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.CHARACTER_LITERAL;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ClassLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ClassLiteral.java
@@ -61,10 +61,10 @@ public class ClassLiteral extends ObjectInstance {
   /**
    * {@inheritDoc}
    * 
-   * @see org.lambdamatic.analyzer.ast.node.Expression#getExpressionType()
+   * @see org.lambdamatic.analyzer.ast.node.Expression#getType()
    */
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.CLASS_LITERAL;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ControlFlowStatement.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ControlFlowStatement.java
@@ -59,7 +59,7 @@ public class ControlFlowStatement extends Statement {
   }
 
   @Override
-  public StatementType getStatementType() {
+  public StatementType getType() {
     return StatementType.CONTROL_FLOW_STMT;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/EnumLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/EnumLiteral.java
@@ -48,7 +48,7 @@ public class EnumLiteral extends ObjectInstance {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.ENUM_LITERAL;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/Expression.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/Expression.java
@@ -123,7 +123,7 @@ public abstract class Expression extends Node implements Comparable<Expression> 
   /**
    * @return the {@link ExpressionType} of this {@link Expression}.
    */
-  public abstract ExpressionType getExpressionType();
+  public abstract ExpressionType getType();
 
   /**
    * Checks if any {@link Expression} element of this {@link ComplexExpression} is of the given
@@ -133,7 +133,7 @@ public abstract class Expression extends Node implements Comparable<Expression> 
    * @return {@code true} if any matches, {@code false} otherwise.
    */
   public boolean anyElementMatches(final ExpressionType type) {
-    return getExpressionType() == type;
+    return getType() == type;
   }
 
   /**

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionStatement.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionStatement.java
@@ -31,7 +31,7 @@ public class ExpressionStatement extends SimpleStatement {
   }
 
   @Override
-  public Statement.StatementType getStatementType() {
+  public Statement.StatementType getType() {
     return StatementType.EXPRESSION_STMT;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionTypeMatcher.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionTypeMatcher.java
@@ -41,7 +41,7 @@ public class ExpressionTypeMatcher extends ExpressionVisitor {
 
   @Override
   public boolean visit(final Expression expr) {
-    if (expr.getExpressionType() == this.expectedExpressionType) {
+    if (expr.getType() == this.expectedExpressionType) {
       this.matchFound = true;
       return false;
     }

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionVisitor.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionVisitor.java
@@ -31,7 +31,7 @@ public abstract class ExpressionVisitor {
    */
   public boolean visit(final Expression expr) {
     if (expr != null) {
-      switch (expr.getExpressionType()) {
+      switch (expr.getType()) {
         case ASSIGNMENT:
           return visitAssignment((Assignment) expr);
         case BOOLEAN_LITERAL:

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionVisitorUtil.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionVisitorUtil.java
@@ -69,8 +69,8 @@ public class ExpressionVisitorUtil {
     }
 
     @Override
-    public ExpressionType getExpressionType() {
-      return this.expression.getExpressionType();
+    public ExpressionType getType() {
+      return this.expression.getType();
     }
 
     @Override

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionsCounter.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ExpressionsCounter.java
@@ -52,7 +52,7 @@ public class ExpressionsCounter extends ExpressionVisitor {
   @Override
   public boolean visit(final Expression expr) {
     // for anything except Local variables, count the expression itself.
-    switch (expr.getExpressionType()) {
+    switch (expr.getType()) {
       case LOCAL_VARIABLE:
       case CAPTURED_ARGUMENT_REF:
         // skip those elements, they can probably not be simplified here

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/FieldAccess.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/FieldAccess.java
@@ -128,7 +128,7 @@ public class FieldAccess extends ComplexExpression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.FIELD_ACCESS;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/InstanceOf.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/InstanceOf.java
@@ -20,7 +20,7 @@ public class InstanceOf extends Expression {
   private final Expression expression;
 
   /** The expected expression type. */
-  private final Type type;
+  private final Type expectedType;
 
   /**
    * Full constructor.
@@ -29,10 +29,10 @@ public class InstanceOf extends Expression {
    * </p>
    * 
    * @param expression the expression being evaluated.
-   * @param type the expected expression type.
+   * @param expectedType the expected expression type.
    */
-  public InstanceOf(final Expression expression, final Type type) {
-    this(generateId(), expression, type, false);
+  public InstanceOf(final Expression expression, final Type expectedType) {
+    this(generateId(), expression, expectedType, false);
   }
 
   /**
@@ -47,16 +47,16 @@ public class InstanceOf extends Expression {
       final boolean inverted) {
     super(id, inverted);
     this.expression = expression;
-    this.type = type;
+    this.expectedType = type;
   }
 
   @Override
   public InstanceOf duplicate(int id) {
-    return new InstanceOf(id, getExpression(), getType(), isInverted());
+    return new InstanceOf(id, getExpression(), getExpectedType(), isInverted());
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.INSTANCE_OF;
   }
 
@@ -78,10 +78,10 @@ public class InstanceOf extends Expression {
   }
 
   /**
-   * @return the type.
+   * @return the expected type.
    */
-  public Type getType() {
-    return this.type;
+  public Type getExpectedType() {
+    return this.expectedType;
   }
 
   /**
@@ -91,7 +91,7 @@ public class InstanceOf extends Expression {
    */
   @Override
   public Expression inverse() {
-    return new InstanceOf(generateId(), this.expression, this.type, !isInverted());
+    return new InstanceOf(generateId(), this.expression, this.expectedType, !isInverted());
   }
 
   /**
@@ -111,9 +111,9 @@ public class InstanceOf extends Expression {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((getExpressionType() == null) ? 0 : getExpressionType().hashCode());
+    result = prime * result + ((getType() == null) ? 0 : getType().hashCode());
     result = prime * result + ((this.expression == null) ? 0 : this.expression.hashCode());
-    result = prime * result + ((this.type == null) ? 0 : this.type.hashCode());
+    result = prime * result + ((this.expectedType == null) ? 0 : this.expectedType.hashCode());
     return result;
   }
 
@@ -139,11 +139,11 @@ public class InstanceOf extends Expression {
     } else if (!this.expression.equals(other.expression)) {
       return false;
     }
-    if (this.type == null) {
-      if (other.type != null) {
+    if (this.expectedType == null) {
+      if (other.expectedType != null) {
         return false;
       }
-    } else if (!this.type.equals(other.type)) {
+    } else if (!this.expectedType.equals(other.expectedType)) {
       return false;
     }
     return true;

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/LambdaExpression.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/LambdaExpression.java
@@ -108,7 +108,7 @@ public class LambdaExpression extends Expression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.LAMBDA_EXPRESSION;
   }
 
@@ -160,6 +160,12 @@ public class LambdaExpression extends Expression {
 
   @Override
   public String toString() {
+    if (this.body.isEmpty()) {
+      return (this.argumentName != null ? this.argumentName : "()") + " -> {}";
+
+    } else if (this.body.size() == 1) {
+      return (this.argumentName != null ? this.argumentName : "()") + " -> " + body.get(0);
+    }
     return (this.argumentName != null ? this.argumentName : "()") + " -> {"
         + String.join(" ", this.body.stream().map(s -> s.toString()).collect(Collectors.toList()))
         + "}";

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/LocalVariable.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/LocalVariable.java
@@ -25,7 +25,7 @@ public class LocalVariable extends Expression {
   /**
    * The variable type's associated {@link Class}.
    */
-  private final Class<?> type;
+  private final Class<?> variableType;
 
   /**
    * Constructor when local variable is provided
@@ -35,11 +35,11 @@ public class LocalVariable extends Expression {
    * 
    * @param index The variable index (as specified in the method bytecode).
    * @param name The variable name.
-   * @param type The variable type.
+   * @param variableType The variable type.
    */
-  public LocalVariable(final int index, final String name, final Class<?> type) {
-    this(generateId(), index, name, type, false);
-    if (type == null) {
+  public LocalVariable(final int index, final String name, final Class<?> variableType) {
+    this(generateId(), index, name, variableType, false);
+    if (variableType == null) {
       throw new IllegalArgumentException("Type of local variable '" + name + "' must not be null");
     }
 
@@ -59,12 +59,12 @@ public class LocalVariable extends Expression {
     super(id, inverted);
     this.index = index;
     this.name = name;
-    this.type = type;
+    this.variableType = type;
   }
 
   @Override
   public LocalVariable duplicate(int id) {
-    return new LocalVariable(id, this.index, this.name, this.type, isInverted());
+    return new LocalVariable(id, this.index, this.name, this.variableType, isInverted());
   }
 
   /**
@@ -84,12 +84,12 @@ public class LocalVariable extends Expression {
   /**
    * @return the variable type.
    */
-  public Class<?> getType() {
-    return this.type;
+  public Class<?> getVariableType() {
+    return this.variableType;
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.LOCAL_VARIABLE;
   }
 
@@ -100,7 +100,7 @@ public class LocalVariable extends Expression {
 
   @Override
   public Class<?> getJavaType() {
-    return this.type;
+    return this.variableType;
   }
 
   @Override
@@ -117,9 +117,9 @@ public class LocalVariable extends Expression {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((getExpressionType() == null) ? 0 : getExpressionType().hashCode());
+    result = prime * result + ((getType() == null) ? 0 : getType().hashCode());
     result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
-    result = prime * result + ((this.type == null) ? 0 : this.type.hashCode());
+    result = prime * result + ((this.variableType == null) ? 0 : this.variableType.hashCode());
     return result;
   }
 
@@ -142,11 +142,11 @@ public class LocalVariable extends Expression {
     } else if (!this.name.equals(other.name)) {
       return false;
     }
-    if (this.type == null) {
-      if (other.type != null) {
+    if (this.variableType == null) {
+      if (other.variableType != null) {
         return false;
       }
-    } else if (!this.type.equals(other.type)) {
+    } else if (!this.variableType.equals(other.variableType)) {
       return false;
     }
     return true;

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/MethodInvocation.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/MethodInvocation.java
@@ -106,7 +106,7 @@ public class MethodInvocation extends ComplexExpression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.METHOD_INVOCATION;
   }
 
@@ -218,7 +218,7 @@ public class MethodInvocation extends ComplexExpression {
    * @return the value of {@code this} Expression.
    */
   public Object getValue() {
-    if (this.source.getExpressionType() == ExpressionType.CLASS_LITERAL) {
+    if (this.source.getType() == ExpressionType.CLASS_LITERAL) {
       return evaluate();
     }
     return evaluate();
@@ -271,7 +271,7 @@ public class MethodInvocation extends ComplexExpression {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((getExpressionType() == null) ? 0 : getExpressionType().hashCode());
+    result = prime * result + ((getType() == null) ? 0 : getType().hashCode());
     result = prime * result + ((this.arguments == null) ? 0 : this.arguments.hashCode());
     result = prime * result + (isInverted() ? 1231 : 1237);
     result = prime * result + ((this.javaMethod == null) ? 0 : this.javaMethod.hashCode());

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/MethodReference.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/MethodReference.java
@@ -90,7 +90,7 @@ public class MethodReference extends ComplexExpression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.METHOD_REFERENCE;
   }
 
@@ -178,7 +178,7 @@ public class MethodReference extends ComplexExpression {
    * @return the value of {@code this} Expression.
    */
   public Object getValue() {
-    if (this.source.getExpressionType() == ExpressionType.CLASS_LITERAL) {
+    if (this.source.getType() == ExpressionType.CLASS_LITERAL) {
       return evaluate();
     }
     return evaluate();
@@ -225,7 +225,7 @@ public class MethodReference extends ComplexExpression {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ((getExpressionType() == null) ? 0 : getExpressionType().hashCode());
+    result = prime * result + ((getType() == null) ? 0 : getType().hashCode());
     result = prime * result + (isInverted() ? 1231 : 1237);
     result = prime * result + ((this.javaMethod == null) ? 0 : this.javaMethod.hashCode());
     result = prime * result + ((this.source == null) ? 0 : this.source.hashCode());

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/NullLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/NullLiteral.java
@@ -41,7 +41,7 @@ public class NullLiteral extends ObjectInstance {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.NULL_LITERAL;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/NumberLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/NumberLiteral.java
@@ -119,7 +119,7 @@ public class NumberLiteral extends ObjectInstance {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.NUMBER_LITERAL;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ObjectInstance.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ObjectInstance.java
@@ -48,7 +48,7 @@ public class ObjectInstance extends Expression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.OBJECT_INSTANCE;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ObjectInstanciation.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ObjectInstanciation.java
@@ -83,10 +83,10 @@ public class ObjectInstanciation extends Expression {
   }
 
   /**
-   * @see org.lambdamatic.analyzer.ast.node.Expression#getExpressionType()
+   * @see org.lambdamatic.analyzer.ast.node.Expression#getType()
    */
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.OBJECT_INSTANCIATION;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/Operation.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/Operation.java
@@ -69,7 +69,7 @@ public class Operation extends ComplexExpression {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.OPERATION;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/ReturnStatement.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/ReturnStatement.java
@@ -27,7 +27,7 @@ public class ReturnStatement extends SimpleStatement {
   }
 
   @Override
-  public StatementType getStatementType() {
+  public StatementType getType() {
     return StatementType.RETURN_STMT;
   }
 

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/Statement.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/Statement.java
@@ -32,7 +32,7 @@ public abstract class Statement extends Node {
   /**
    * @return the {@link StatementType} of this {@link Statement}.
    */
-  public abstract StatementType getStatementType();
+  public abstract StatementType getType();
 
   /**
    * Sets the parent of this statement in the AST.

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/StatementVisitor.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/StatementVisitor.java
@@ -25,7 +25,7 @@ public abstract class StatementVisitor {
    */
   public boolean visit(final Statement stmt) {
     if (stmt != null) {
-      switch (stmt.getStatementType()) {
+      switch (stmt.getType()) {
         case EXPRESSION_STMT:
           return visitExpressionStatement((ExpressionStatement) stmt);
         case CONTROL_FLOW_STMT:

--- a/src/main/java/org/lambdamatic/analyzer/ast/node/StringLiteral.java
+++ b/src/main/java/org/lambdamatic/analyzer/ast/node/StringLiteral.java
@@ -50,7 +50,7 @@ public class StringLiteral extends ObjectInstance {
   }
 
   @Override
-  public ExpressionType getExpressionType() {
+  public ExpressionType getType() {
     return ExpressionType.STRING_LITERAL;
   }
 


### PR DESCRIPTION
So that `expression.getExpressionType()` becomes
`expression.getType()` to avoid the repetition of
`expression` in the method name.
Same change applies on `Statement#getStatementType`
Side effect on other methods that get a more explicit
name.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>